### PR TITLE
Add Vision OCR with verbatim store and term index

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CCTV runs as a menu bar app and captures a screenshot of all connected displays 
 ## Features
 
 - **Automatic screenshotting** – Captures all displays every 60 seconds (no audio)
+- **OCR text index** – Extracts on-screen text with macOS Vision OCR and stores it verbatim plus a term→times index for later search
 - **Daily video compilation** – Automatically compiles screenshots into MP4 format each day
 - **Menu bar control** – Start/stop capturing, compile videos manually, view storage folder
 - **Resume on wake** – Resumes capturing after sleep and catches up on missed compilations
@@ -42,22 +43,28 @@ The bundled app will be located at `.build/release/CCTV.app`.
 
 ## Storage
 
-Screenshots and videos are saved to:
+Screenshots, videos, and OCR text are saved to:
 ```
 ~/Library/Application Support/CCTV/
 ├── screenshots/
 │   ├── YYYY-MM-DD/
-│   │   ├── display-0_HH-MM-SS.jpg
-│   │   ├── display-0_HH-MM-SS.jpg
+│   │   ├── display-0_HH-mm-ss.jpg
 │   │   └── ...
 │   └── ...
-└── videos/
-    ├── YYYY-MM-DD.mp4
-    ├── YYYY-MM-DD-display-1.mp4
-    └── ...
+├── videos/
+│   ├── YYYY-MM-DD.mp4
+│   ├── YYYY-MM-DD-display-1.mp4
+│   └── ...
+└── ocr/
+    ├── verbatim/
+    │   └── YYYY-MM-DD/
+    │       ├── display-0_HH-mm-ss.json
+    │       └── ...
+    └── index.json
 ```
 
-Screenshots are automatically deleted after successful video compilation.
+Screenshots are automatically deleted after successful video compilation. OCR verbatim
+records and the term index are kept so they can power a future search UI.
 
 ## Menu Bar Options
 
@@ -75,6 +82,7 @@ Screenshots are automatically deleted after successful video compilation.
 1. Every 60 seconds, the app uses `ScreenCaptureKit` to capture all displays at 2x resolution
 2. Each display is saved as a JPEG with 70% compression
 3. Screenshots are timestamped and organized by date
+4. Vision OCR extracts text from each image; the full text is stored under `ocr/verbatim/` and terms are appended to `ocr/index.json`
 
 ### Compilation Phase
 - Every 5 minutes, the app checks if it's 00:05–00:10 (midnight window)

--- a/Sources/CCTV/OCRProcessor.swift
+++ b/Sources/CCTV/OCRProcessor.swift
@@ -1,0 +1,20 @@
+import CoreGraphics
+import Vision
+
+final class OCRProcessor {
+	/// Extracts readable text from a screenshot using macOS Vision OCR.
+	func recognizeText(in image: CGImage) async throws -> String {
+		let request = VNRecognizeTextRequest()
+		request.recognitionLevel = .accurate
+		request.usesLanguageCorrection = true
+
+		let handler = VNImageRequestHandler(cgImage: image, options: [:])
+		try handler.perform([request])
+
+		let observations = request.results ?? []
+		let lines = observations.compactMap { observation in
+			observation.topCandidates(1).first?.string
+		}
+		return lines.joined(separator: "\n")
+	}
+}

--- a/Sources/CCTV/OCRStore.swift
+++ b/Sources/CCTV/OCRStore.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Persists OCR output as verbatim per-capture records and an inverted term→times index.
+actor OCRStore {
+	static let shared = OCRStore()
+
+	private struct VerbatimRecord: Encodable {
+		let timestamp: String
+		let displayIndex: Int
+		let text: String
+	}
+
+	private let isoFormatter: ISO8601DateFormatter = {
+		let formatter = ISO8601DateFormatter()
+		formatter.formatOptions = [.withInternetDateTime]
+		return formatter
+	}()
+
+	private let encoder: JSONEncoder = {
+		let encoder = JSONEncoder()
+		encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+		return encoder
+	}()
+
+	func store(text: String, displayIndex: Int, date: Date) throws {
+		let timestamp = isoFormatter.string(from: date)
+		try writeVerbatim(
+			text: text,
+			displayIndex: displayIndex,
+			date: date,
+			timestamp: timestamp
+		)
+		try updateIndex(text: text, timestamp: timestamp)
+	}
+
+	private func writeVerbatim(
+		text: String,
+		displayIndex: Int,
+		date: Date,
+		timestamp: String
+	) throws {
+		let directory = StorageManager.shared.ocrVerbatimDirectory(for: date)
+		try StorageManager.shared.ensureDirectory(directory)
+
+		let filename = StorageManager.shared.ocrVerbatimFilename(
+			displayIndex: displayIndex,
+			date: date
+		)
+		let record = VerbatimRecord(
+			timestamp: timestamp,
+			displayIndex: displayIndex,
+			text: text
+		)
+		let data = try encoder.encode(record)
+		try data.write(
+			to: directory.appendingPathComponent(filename),
+			options: .atomic
+		)
+	}
+
+	private func updateIndex(text: String, timestamp: String) throws {
+		let terms = Self.tokenize(text)
+		guard !terms.isEmpty else { return }
+
+		let indexURL = StorageManager.shared.ocrIndexURL
+		try StorageManager.shared.ensureDirectory(
+			indexURL.deletingLastPathComponent()
+		)
+
+		var index = loadIndex(from: indexURL)
+		for term in terms {
+			var times = index[term] ?? []
+			if !times.contains(timestamp) {
+				times.append(timestamp)
+				index[term] = times
+			}
+		}
+
+		let data = try JSONSerialization.data(
+			withJSONObject: index,
+			options: [.prettyPrinted, .sortedKeys]
+		)
+		try data.write(to: indexURL, options: .atomic)
+	}
+
+	private func loadIndex(from url: URL) -> [String: [String]] {
+		guard let data = try? Data(contentsOf: url),
+			  let object = try? JSONSerialization.jsonObject(with: data),
+			  let parsed = object as? [String: [String]] else {
+			return [:]
+		}
+		return parsed
+	}
+
+	/// Lowercased tokens of length ≥ 2 matching `[a-z0-9][a-z0-9_-]*`.
+	static func tokenize(_ text: String) -> Set<String> {
+		let lowered = text.lowercased()
+		guard let regex = try? NSRegularExpression(
+			pattern: "[a-z0-9][a-z0-9_-]*"
+		) else {
+			return []
+		}
+
+		let range = NSRange(lowered.startIndex..<lowered.endIndex, in: lowered)
+		let matches = regex.matches(in: lowered, range: range)
+
+		var terms = Set<String>()
+		for match in matches {
+			guard let matchRange = Range(match.range, in: lowered) else { continue }
+			let term = String(lowered[matchRange])
+			if term.count >= 2 {
+				terms.insert(term)
+			}
+		}
+		return terms
+	}
+}

--- a/Sources/CCTV/ScreenshotCapture.swift
+++ b/Sources/CCTV/ScreenshotCapture.swift
@@ -37,6 +37,19 @@ final class ScreenshotCapture {
 			let fileURL = dir.appendingPathComponent(filename)
 
 			try saveAsJPEG(image: image, to: fileURL, quality: 0.7)
+
+			// OCR is best-effort: a recognition or store failure must not
+			// prevent the screenshot from being kept.
+			do {
+				let text = try await OCRProcessor().recognizeText(in: image)
+				try await OCRStore.shared.store(
+					text: text,
+					displayIndex: index,
+					date: now
+				)
+			} catch {
+				// Intentionally ignored — capture already succeeded.
+			}
 		}
 	}
 

--- a/Sources/CCTV/StorageManager.swift
+++ b/Sources/CCTV/StorageManager.swift
@@ -39,6 +39,20 @@ final class StorageManager {
 			.appendingPathComponent("\(dateString).mp4")
 	}
 
+	func ocrVerbatimDirectory(for date: Date = Date()) -> URL {
+		let dateString = dateFormatter.string(from: date)
+		return baseURL
+			.appendingPathComponent("ocr", isDirectory: true)
+			.appendingPathComponent("verbatim", isDirectory: true)
+			.appendingPathComponent(dateString, isDirectory: true)
+	}
+
+	var ocrIndexURL: URL {
+		baseURL
+			.appendingPathComponent("ocr", isDirectory: true)
+			.appendingPathComponent("index.json")
+	}
+
 	func ensureDirectory(_ url: URL) throws {
 		try FileManager.default.createDirectory(
 			at: url,
@@ -49,6 +63,11 @@ final class StorageManager {
 	func screenshotFilename(displayIndex: Int, date: Date = Date()) -> String {
 		let timestamp = timestampFormatter.string(from: date)
 		return "display-\(displayIndex)_\(timestamp).jpg"
+	}
+
+	func ocrVerbatimFilename(displayIndex: Int, date: Date = Date()) -> String {
+		let timestamp = timestampFormatter.string(from: date)
+		return "display-\(displayIndex)_\(timestamp).json"
 	}
 
 	func screenshotCountToday() -> Int {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,86 @@
+# CCTV — Specification
+
+How CCTV should work. This is the source of truth for behaviour; if code, README or
+notes disagree with this document, change them to match — or change this document
+first when the product decision has moved on.
+
+## Purpose
+
+CCTV records what happens on your screen so you can review how you spent your time,
+spot bottlenecks and increase throughput. It takes a screenshot every minute and
+compiles each day into a time-lapse video. It also extracts on-screen text via
+macOS OCR so that text can later be searched by time.
+
+## Shape of the app
+
+A menu bar accessory app. No dock icon, no main window. Everything is driven from the
+menu bar item.
+
+## Capture
+
+- Every 60 seconds, all connected displays are captured at 2x via ScreenCaptureKit.
+- Saved as JPEG at 70% quality, no cursor, one file per display.
+- Capture does not start on its own; the user starts it from the menu.
+- After each display image is saved, macOS Vision OCR (`VNRecognizeTextRequest`,
+  accurate recognition with language correction) extracts the on-screen text.
+- OCR is best-effort: a recognition or store failure must not prevent the screenshot
+  from being kept.
+
+## OCR storage
+
+OCR output is stored under `~/Library/Application Support/CCTV/ocr/` and **outlives**
+screenshot deletion after video compilation, so a future search UI can still use it.
+
+```
+ocr/
+  verbatim/YYYY-MM-DD/
+    display-0_HH-mm-ss.json
+  index.json
+```
+
+### Verbatim records
+
+One JSON file per capture, named to mirror the screenshot. Fields:
+
+| Field | Meaning |
+| --- | --- |
+| `timestamp` | ISO8601 UTC instant of the capture |
+| `displayIndex` | Display that was captured |
+| `text` | Full OCR string for that image |
+
+### Term index
+
+`ocr/index.json` is an inverted index mapping each term to the list of capture
+timestamps (ISO8601 UTC) where it appeared:
+
+```json
+{
+  "invoice": ["2026-08-08T15:31:00Z", "2026-08-08T15:32:00Z"],
+  "netlify": ["2026-08-08T15:31:00Z"]
+}
+```
+
+- Terms are lowercased tokens of length ≥ 2 matching `[a-z0-9][a-z0-9_-]*`.
+- A term receives a capture's timestamp at most once for that capture.
+- Index updates are serialized so concurrent multi-display captures cannot corrupt
+  the file.
+
+No search UI is part of this behaviour yet; the stores exist so one can be added later.
+
+## Compilation
+
+- H.264 MP4 at 30 FPS, one video per display per day.
+- Runs automatically between 00:05 and 00:10, and on wake for any of the last 7 days
+  that has screenshots but no video.
+- Screenshots for a day are deleted once its video compiles. OCR data is kept.
+
+## Storage
+
+`~/Library/Application Support/CCTV/`, with `screenshots/YYYY-MM-DD/`,
+`videos/YYYY-MM-DD.mp4`, and `ocr/` as above.
+
+**Open Storage Folder** reveals that folder, creating it first if capture has never run.
+
+## Known constraints
+
+- Compilation uses the system timezone, so the midnight window follows local time.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- After each screenshot save, run macOS Vision OCR (`VNRecognizeTextRequest`, accurate + language correction) on the in-memory image.
- Persist a verbatim JSON record per capture under `ocr/verbatim/YYYY-MM-DD/` and append terms to an inverted `ocr/index.json` (term → ISO8601 timestamps).
- OCR is best-effort and does not fail capture; OCR data is kept after screenshots are deleted on video compile.
- Documented in `docs/spec.md` and the README storage tree.

## Notes
- No search UI in this change — the stores are the foundation for one later.
- This Linux cloud environment has no Swift/macOS SDK, so `make build` could not be run here. Please build on macOS with `make build` / `make run`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2824a8e7-27ad-4e44-b3c3-4835981ea649?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2824a8e7-27ad-4e44-b3c3-4835981ea649&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

